### PR TITLE
Allow plugin execution and validation to be skipped

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -156,6 +156,53 @@
                 </plugins>
             </build>
         </profile>
+        <profile>
+            <id>only-eclipse</id>
+            <activation>
+                <property>
+                    <name>m2e.version</name>
+                </property>
+            </activation>
+            <build>
+                <pluginManagement>
+                    <plugins>
+                        <!--This plugin's configuration is used to store 
+                            Eclipse m2e settings only. It has no influence on the Maven build itself. -->
+                        <plugin>
+                            <groupId>org.eclipse.m2e</groupId>
+                            <artifactId>lifecycle-mapping</artifactId>
+                            <version>1.0.0</version>
+                            <configuration>
+                                <lifecycleMappingMetadata>
+                                    <pluginExecutions>
+                                        <pluginExecution>
+                                            <pluginExecutionFilter>
+                                                <groupId>
+                                                    org.apache.maven.plugins
+                                                </groupId>
+                                                <artifactId>
+                                                    maven-plugin-plugin
+                                                </artifactId>
+                                                <versionRange>
+                                                    [3.4,)
+                                                </versionRange>
+                                                <goals>
+                                                    <goal>descriptor</goal>
+                                                    <goal>helpmojo</goal>
+                                                </goals>
+                                            </pluginExecutionFilter>
+                                            <action>
+                                                <ignore></ignore>
+                                            </action>
+                                        </pluginExecution>
+                                    </pluginExecutions>
+                                </lifecycleMappingMetadata>
+                            </configuration>
+                        </plugin>
+                    </plugins>
+                </pluginManagement>
+            </build>
+        </profile>
     </profiles>
 
     <distributionManagement>


### PR DESCRIPTION
This also makes some formatting changes and moves the package for the plugin execution. Added help text to all of the existing parameters and new ones for better discovery

Fixes #11

2 new parameters: 

- `skipRepositoryCheck` (with user property `githook.plugin. skipRepositoryCheck `)
    - Fixes the case of #11 where you want to probably install the hook if the .git repository is there, but don't explode if it's not there
- `skip` (with user property `githook.plugin.skip`)
    - Skips the entire plugin execution altogether
